### PR TITLE
feat: co-visitor invitations, nearby places filtering, and place picker UI

### DIFF
--- a/lib/models/nearby_places_search_form.dart
+++ b/lib/models/nearby_places_search_form.dart
@@ -1,19 +1,22 @@
 import 'package:gastrorate/models/coordinates.dart';
 
 class NearbyPlacesSearchForm {
-  List<String> includedTypes;
+  List<String> includedPrimaryTypes;
   int maxResultCount;
+  String rankPreference;
   LocationRestriction locationRestriction;
 
   NearbyPlacesSearchForm({
-    required this.includedTypes,
+    required this.includedPrimaryTypes,
     required this.maxResultCount,
+    this.rankPreference = 'DISTANCE',
     required this.locationRestriction,
   });
 
   Map<String, dynamic> toJson() => {
-        'includedTypes': includedTypes,
+        'includedPrimaryTypes': includedPrimaryTypes,
         'maxResultCount': maxResultCount,
+        'rankPreference': rankPreference,
         'locationRestriction': locationRestriction.toJson(),
       };
 }

--- a/lib/models/place.dart
+++ b/lib/models/place.dart
@@ -40,31 +40,63 @@ class Place {
   factory Place.fromJson(Map<String, dynamic> json) => _$PlaceFromJson(json);
 
   factory Place.fromGoogleJson(Map<String, dynamic> json) {
-    final displayName = json['displayName'] as Map<String, dynamic>?;
-    final currentOpeningHours = json['currentOpeningHours'] as Map<String, dynamic>?;
+    const priceLevelMap = {
+      'FREE': PriceLevel.FREE,
+      'INEXPENSIVE': PriceLevel.INEXPENSIVE,
+      'MODERATE': PriceLevel.MODERATE,
+      'EXPENSIVE': PriceLevel.EXPENSIVE,
+      'VERY_EXPENSIVE': PriceLevel.VERY_EXPENSIVE,
+      'UNKNOWN': PriceLevel.UNKNOWN,
+      'PRICE_LEVEL_FREE': PriceLevel.PRICE_LEVEL_FREE,
+      'PRICE_LEVEL_INEXPENSIVE': PriceLevel.PRICE_LEVEL_INEXPENSIVE,
+      'PRICE_LEVEL_MODERATE': PriceLevel.PRICE_LEVEL_MODERATE,
+      'PRICE_LEVEL_EXPENSIVE': PriceLevel.PRICE_LEVEL_EXPENSIVE,
+      'PRICE_LEVEL_VERY_EXPENSIVE': PriceLevel.PRICE_LEVEL_VERY_EXPENSIVE,
+    };
     return Place(
-      name: displayName?['text'] as String?,
+      id: json['id'] ?? (json['name'] as String?)?.split('/').last,
+      name: json['displayName']?['text'] ?? json['name'],
       address: json['formattedAddress'] as String?,
-      googleRating: (json['rating'] as num?)?.toDouble(),
-      url: json['googleMapsUri'] as String?,
-      webSiteUrl: json['websiteUri'] as String?,
-      contactNumber: json['nationalPhoneNumber'] as String?,
-      openingHours: currentOpeningHours != null
-          ? PlaceOpeningHours(
-              openNow: currentOpeningHours['openNow'] as bool?,
-              weekdayText: (currentOpeningHours['weekdayDescriptions'] as List<dynamic>?)
-                  ?.map((e) => e as String)
-                  .toList(),
-            )
-          : null,
-      photos: (json['photos'] as List<dynamic>?)
+      city: (json['addressComponents'] as List?)
+          ?.firstWhere(
+            (comp) => (comp['types'] as List?)?.contains('locality') ?? false,
+            orElse: () => null,
+          )?['longText'] as String?,
+      postalCode: int.tryParse(
+        (json['addressComponents'] as List?)
+                ?.firstWhere(
+                  (comp) => (comp['types'] as List?)?.contains('postal_code') ?? false,
+                  orElse: () => null,
+                )?['longText'] ??
+            '',
+      ),
+      country: (json['addressComponents'] as List?)
+          ?.firstWhere(
+            (comp) => (comp['types'] as List?)?.contains('country') ?? false,
+            orElse: () => null,
+          )?['longText'] as String?,
+      contactNumber: json['internationalPhoneNumber'] as String?,
+      openingHours: json['regularOpeningHours'] == null
+          ? null
+          : PlaceOpeningHours.fromJson(json['regularOpeningHours'] as Map<String, dynamic>),
+      photos: (json['photos'] as List?)
           ?.map((e) => Photo.fromGoogleJson(e as Map<String, dynamic>))
           .toList(),
+      priceLevel: priceLevelMap[json['priceLevel'] as String?],
       reviews: (json['reviews'] as List<dynamic>?)
           ?.map((e) => PlaceReview.fromGoogleJson(e as Map<String, dynamic>))
           .toList(),
-      visitedAt: DateTime.now(),
+      googleRating: (json['rating'] as num?)?.toDouble(),
+      url: json['googleMapsUri'] as String?,
+      webSiteUrl: json['websiteUri'] as String?,
+      coordinates: json['location'] == null
+          ? null
+          : Coordinates(
+              latitude: (json['location']['latitude'] as num?)?.toDouble(),
+              longitude: (json['location']['longitude'] as num?)?.toDouble(),
+            ),
       isFavorite: false,
+      distance: null,
     );
   }
   Map<String, dynamic> toJson() => _$PlaceToJson(this);

--- a/lib/models/visit_invitation.dart
+++ b/lib/models/visit_invitation.dart
@@ -8,6 +8,8 @@ class VisitInvitation {
   String? placeId;
   String? placeName;
   String? inviterId;
+  String? inviterName;
+  String? inviterProfileImageUrl;
   String? inviteeId;
   String? status; // "PENDING" | "ACCEPTED" | "DECLINED"
   DateTime? createdAt;
@@ -20,6 +22,8 @@ class VisitInvitation {
     this.placeId,
     this.placeName,
     this.inviterId,
+    this.inviterName,
+    this.inviterProfileImageUrl,
     this.inviteeId,
     this.status,
     this.createdAt,
@@ -34,6 +38,8 @@ class VisitInvitation {
           placeId == other.placeId &&
           placeName == other.placeName &&
           inviterId == other.inviterId &&
+          inviterName == other.inviterName &&
+          inviterProfileImageUrl == other.inviterProfileImageUrl &&
           inviteeId == other.inviteeId &&
           status == other.status &&
           createdAt == other.createdAt);
@@ -44,19 +50,23 @@ class VisitInvitation {
       placeId.hashCode ^
       placeName.hashCode ^
       inviterId.hashCode ^
+      inviterName.hashCode ^
+      inviterProfileImageUrl.hashCode ^
       inviteeId.hashCode ^
       status.hashCode ^
       createdAt.hashCode;
 
   @override
   String toString() =>
-      'VisitInvitation{ id: $id, placeId: $placeId, placeName: $placeName, inviterId: $inviterId, inviteeId: $inviteeId, status: $status, createdAt: $createdAt }';
+      'VisitInvitation{ id: $id, placeId: $placeId, placeName: $placeName, inviterId: $inviterId, inviterName: $inviterName, inviteeId: $inviteeId, status: $status, createdAt: $createdAt }';
 
   VisitInvitation copyWith({
     String? id,
     String? placeId,
     String? placeName,
     String? inviterId,
+    String? inviterName,
+    String? inviterProfileImageUrl,
     String? inviteeId,
     String? status,
     DateTime? createdAt,
@@ -66,6 +76,8 @@ class VisitInvitation {
       placeId: placeId ?? this.placeId,
       placeName: placeName ?? this.placeName,
       inviterId: inviterId ?? this.inviterId,
+      inviterName: inviterName ?? this.inviterName,
+      inviterProfileImageUrl: inviterProfileImageUrl ?? this.inviterProfileImageUrl,
       inviteeId: inviteeId ?? this.inviteeId,
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,
@@ -77,6 +89,8 @@ class VisitInvitation {
         'placeId': placeId,
         'placeName': placeName,
         'inviterId': inviterId,
+        'inviterName': inviterName,
+        'inviterProfileImageUrl': inviterProfileImageUrl,
         'inviteeId': inviteeId,
         'status': status,
         'createdAt': createdAt?.toIso8601String(),
@@ -87,6 +101,8 @@ class VisitInvitation {
         placeId: map['placeId'] as String?,
         placeName: map['placeName'] as String?,
         inviterId: map['inviterId'] as String?,
+        inviterName: map['inviterName'] as String?,
+        inviterProfileImageUrl: map['inviterProfileImageUrl'] as String?,
         inviteeId: map['inviteeId'] as String?,
         status: map['status'] as String?,
         createdAt: map['createdAt'] != null ? DateTime.parse(map['createdAt']) : null,

--- a/lib/models/visit_invitation.g.dart
+++ b/lib/models/visit_invitation.g.dart
@@ -12,6 +12,8 @@ VisitInvitation _$VisitInvitationFromJson(Map<String, dynamic> json) =>
       placeId: json['placeId'] as String?,
       placeName: json['placeName'] as String?,
       inviterId: json['inviterId'] as String?,
+      inviterName: json['inviterName'] as String?,
+      inviterProfileImageUrl: json['inviterProfileImageUrl'] as String?,
       inviteeId: json['inviteeId'] as String?,
       status: json['status'] as String?,
       createdAt: json['createdAt'] == null
@@ -25,6 +27,8 @@ Map<String, dynamic> _$VisitInvitationToJson(VisitInvitation instance) =>
       'placeId': instance.placeId,
       'placeName': instance.placeName,
       'inviterId': instance.inviterId,
+      'inviterName': instance.inviterName,
+      'inviterProfileImageUrl': instance.inviterProfileImageUrl,
       'inviteeId': instance.inviteeId,
       'status': instance.status,
       'createdAt': instance.createdAt?.toIso8601String(),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -79,7 +79,7 @@ class _HomeState extends State<Home> {
     LocationHelper().getCurrentLocation().then((value) => initialPosition = LatLng(value.latitude, value.longitude));
     setState(() {
       _mapsInitialized = true;
-      (widget.mapsImplementation as GoogleMapsFlutterAndroid).useAndroidViewSurface = true;
+      (widget.mapsImplementation as GoogleMapsFlutterAndroid).useAndroidViewSurface = false;
     });
   }
 
@@ -207,6 +207,10 @@ class _HomeState extends State<Home> {
                 selectInitialPosition: true,
                 usePlaceDetailSearch: true,
                 zoomControlsEnabled: true,
+                autocompleteRadius: 50000,
+                autocompleteTypes: ['restaurant'],
+                selectedPlaceWidgetBuilder: (context, data, state, isSearchBarFocused) =>
+                    _defaultPlaceWidgetBuilder(context, data, state),
                 onPlacePicked: (PickResult result) {
                   setState(() {
                     selectedPlace = Place.fromPickResult(result);
@@ -229,5 +233,139 @@ class _HomeState extends State<Home> {
       highlightElevation: 8.0,
       splashColor: Colors.white.withOpacity(0.3),
     );
+  }
+
+  Widget _defaultPlaceWidgetBuilder(BuildContext context, PickResult? data, SearchingState state) {
+    return FloatingCard(
+      bottomPosition: 0,
+      leftPosition: 0,
+      rightPosition: 0,
+      width: double.infinity,
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      elevation: 10.0,
+      color: Theme.of(context).cardColor,
+      child: state == SearchingState.Searching ? _buildLoadingIndicator() : _buildSelectionDetails(context, data!),
+    );
+  }
+
+  Widget _buildLoadingIndicator() {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 32),
+      child: Center(
+        child: SizedBox(width: 28, height: 28, child: CircularProgressIndicator()),
+      ),
+    );
+  }
+
+  Widget _buildSelectionDetails(BuildContext context, PickResult result) {
+    selectedPlace = Place.fromPickResult(result);
+    final rating = result.rating;
+    final openNow = result.openingHours?.openNow;
+    final priceLevelText = _priceLevelText(result.priceLevel?.index);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 40, height: 4,
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Text(
+            selectedPlace?.name ?? "",
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              if (rating != null) ...[
+                const Icon(Icons.star_rounded, color: Color(0xFFFFB300), size: 18),
+                const SizedBox(width: 3),
+                Text(rating.toStringAsFixed(1), style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14)),
+                const SizedBox(width: 12),
+              ],
+              if (priceLevelText != null) ...[
+                Text(priceLevelText, style: TextStyle(color: Colors.green.shade700, fontSize: 14, fontWeight: FontWeight.w600)),
+                const SizedBox(width: 12),
+              ],
+              if (openNow != null)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: openNow ? Colors.green.shade100 : Colors.red.shade100,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    openNow ? "Open now" : "Closed",
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: openNow ? Colors.green.shade800 : Colors.red.shade800,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.location_on_outlined, size: 16, color: Colors.grey.shade600),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  result.formattedAddress ?? "${selectedPlace?.address ?? ''}, ${selectedPlace?.city ?? ''}",
+                  style: TextStyle(fontSize: 13, color: Colors.grey.shade700),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: () {
+                setState(() {
+                  selectedPlace = widget.places?.firstWhere(
+                    (place) => place.url == selectedPlace?.url,
+                    orElse: () => selectedPlace ?? Place(),
+                  );
+                  widget.onInitPlaceForm(selectedPlace ?? Place());
+                  Navigator.of(context).pop();
+                });
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: MyColors.primaryDarkColor,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+              ),
+              child: const Text("Select this place", style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: MyColors.navbarItemColor)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String? _priceLevelText(int? index) {
+    switch (index) {
+      case 1: return '€';
+      case 2: return '€€';
+      case 3: return '€€€';
+      case 4: return '€€€€';
+      default: return null;
+    }
   }
 }

--- a/lib/screens/notifications.dart
+++ b/lib/screens/notifications.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gastrorate/models/friend_request_dto.dart';
+import 'package:gastrorate/models/visit_invitation.dart';
 import 'package:gastrorate/theme/my_colors.dart';
 import 'package:gastrorate/widgets/custom_app_bar.dart';
 import 'package:gastrorate/widgets/custom_text.dart';
@@ -9,13 +10,19 @@ class Notifications extends StatelessWidget {
   const Notifications({
     super.key,
     required this.pendingRequests,
+    required this.pendingInvitations,
     required this.onAccept,
     required this.onDecline,
+    required this.onAcceptInvitation,
+    required this.onDeclineInvitation,
   });
 
   final List<FriendRequestDto>? pendingRequests;
+  final List<VisitInvitation> pendingInvitations;
   final Function(String friendshipId) onAccept;
   final Function(String friendshipId) onDecline;
+  final Function(String invitationId) onAcceptInvitation;
+  final Function(String invitationId) onDeclineInvitation;
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +30,7 @@ class Notifications extends StatelessWidget {
             ?.where((r) => r.status == 'PENDING')
             .toList() ??
         [];
+    final hasContent = pending.isNotEmpty || pendingInvitations.isNotEmpty;
 
     return Scaffold(
       appBar: CustomAppBar(
@@ -32,83 +40,199 @@ class Notifications extends StatelessWidget {
         ),
         backgroundColor: MyColors.appbarColor,
       ),
-      body: pending.isEmpty
+      body: !hasContent
           ? const Center(child: CustomText("No new notifications"))
           : ListView(
               padding: const EdgeInsets.all(16),
               children: [
-                CustomText(
-                  "Friend Requests",
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                ),
-                const VerticalSpacer(8),
-                ...pending.map((req) => Card(
-                      margin: const EdgeInsets.only(bottom: 8),
-                      child: Padding(
-                        padding: const EdgeInsets.all(12),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            CircleAvatar(
-                              radius: 24,
-                              backgroundImage: req.requesterProfileImageUrl != null
-                                  ? NetworkImage(req.requesterProfileImageUrl!)
-                                  : null,
-                              child: req.requesterProfileImageUrl == null
-                                  ? const Icon(Icons.person)
-                                  : null,
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  CustomText(
-                                    req.requesterName ?? '',
-                                    style: const TextStyle(fontWeight: FontWeight.w600),
-                                  ),
-                                  if (req.requesterUsername != null || req.requesterTag != null)
-                                    CustomText(
-                                      '@${req.requesterUsername ?? ''}#${req.requesterTag ?? ''}',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .bodySmall
-                                          ?.copyWith(color: Colors.grey),
-                                    ),
-                                  const SizedBox(height: 8),
-                                  Row(
-                                    children: [
-                                      Expanded(
-                                        child: FilledButton(
-                                          onPressed: () => onAccept(req.friendshipId!),
-                                          child: const Text("Accept"),
-                                        ),
-                                      ),
-                                      const SizedBox(width: 8),
-                                      Expanded(
-                                        child: OutlinedButton(
-                                          style: OutlinedButton.styleFrom(
-                                            foregroundColor: Colors.red,
-                                            side: const BorderSide(color: Colors.red),
-                                          ),
-                                          onPressed: () => onDecline(req.friendshipId!),
-                                          child: const Text("Decline"),
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    )),
+                if (pending.isNotEmpty) ...[
+                  CustomText(
+                    "Friend Requests",
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const VerticalSpacer(8),
+                  ...pending.map((req) => _FriendRequestCard(
+                        req: req,
+                        onAccept: onAccept,
+                        onDecline: onDecline,
+                      )),
+                  const VerticalSpacer(8),
+                ],
+                if (pendingInvitations.isNotEmpty) ...[
+                  CustomText(
+                    "Visit Invitations",
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const VerticalSpacer(8),
+                  ...pendingInvitations.map((inv) => _VisitInvitationCard(
+                        invitation: inv,
+                        onAccept: onAcceptInvitation,
+                        onDecline: onDeclineInvitation,
+                      )),
+                ],
               ],
             ),
+    );
+  }
+}
+
+class _FriendRequestCard extends StatelessWidget {
+  const _FriendRequestCard({
+    required this.req,
+    required this.onAccept,
+    required this.onDecline,
+  });
+
+  final FriendRequestDto req;
+  final Function(String) onAccept;
+  final Function(String) onDecline;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            CircleAvatar(
+              radius: 24,
+              backgroundImage: req.requesterProfileImageUrl != null
+                  ? NetworkImage(req.requesterProfileImageUrl!)
+                  : null,
+              child: req.requesterProfileImageUrl == null
+                  ? const Icon(Icons.person)
+                  : null,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CustomText(
+                    req.requesterName ?? '',
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  if (req.requesterUsername != null || req.requesterTag != null)
+                    CustomText(
+                      '@${req.requesterUsername ?? ''}#${req.requesterTag ?? ''}',
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: Colors.grey),
+                    ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: () => onAccept(req.friendshipId!),
+                          child: const Text("Accept"),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: OutlinedButton(
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.red,
+                            side: const BorderSide(color: Colors.red),
+                          ),
+                          onPressed: () => onDecline(req.friendshipId!),
+                          child: const Text("Decline"),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VisitInvitationCard extends StatelessWidget {
+  const _VisitInvitationCard({
+    required this.invitation,
+    required this.onAccept,
+    required this.onDecline,
+  });
+
+  final VisitInvitation invitation;
+  final Function(String) onAccept;
+  final Function(String) onDecline;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            CircleAvatar(
+              radius: 24,
+              backgroundImage: invitation.inviterProfileImageUrl != null
+                  ? NetworkImage(invitation.inviterProfileImageUrl!)
+                  : null,
+              child: invitation.inviterProfileImageUrl == null
+                  ? const Icon(Icons.restaurant)
+                  : null,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CustomText(
+                    invitation.placeName ?? 'Unknown place',
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  CustomText(
+                    'Invited by ${invitation.inviterName ?? invitation.inviterId ?? ''}',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Colors.grey),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: () => onAccept(invitation.id!),
+                          child: const Text("Accept"),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: OutlinedButton(
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.red,
+                            side: const BorderSide(color: Colors.red),
+                          ),
+                          onPressed: () => onDecline(invitation.id!),
+                          child: const Text("Decline"),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/notifications_page.dart
+++ b/lib/screens/notifications_page.dart
@@ -1,9 +1,11 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:gastrorate/models/friend_request_dto.dart';
+import 'package:gastrorate/models/visit_invitation.dart';
 import 'package:gastrorate/screens/notifications.dart';
 import 'package:gastrorate/store/app_state.dart';
 import 'package:gastrorate/store/friendships/friendships_actions.dart';
+import 'package:gastrorate/store/invitations/invitations_actions.dart';
 
 class NotificationsPage extends StatelessWidget {
   const NotificationsPage({super.key});
@@ -16,12 +18,16 @@ class NotificationsPage extends StatelessWidget {
         final userId = store.state.authState.loggedUser?.id;
         if (userId != null) {
           store.dispatch(FetchAllFriendRequestsAction(userId));
+          store.dispatch(FetchPendingInvitationsAction(userId));
         }
       },
       builder: (BuildContext context, ViewModel vm) => Notifications(
         pendingRequests: vm.pendingRequests,
+        pendingInvitations: vm.pendingInvitations,
         onAccept: vm.onAccept,
         onDecline: vm.onDecline,
+        onAcceptInvitation: vm.onAcceptInvitation,
+        onDeclineInvitation: vm.onDeclineInvitation,
       ),
     );
   }
@@ -36,20 +42,29 @@ class Factory extends VmFactory<AppState, NotificationsPage, ViewModel> {
                 ?.where((r) => r.status == 'PENDING')
                 .toList() ??
             [],
+        pendingInvitations: state.invitationsState.pendingInvitations ?? [],
         onAccept: (String id) => dispatch(AcceptFriendRequestAction(id)),
         onDecline: (String id) => dispatch(DeclineFriendRequestAction(id)),
+        onAcceptInvitation: (String id) => dispatch(AcceptInvitationAction(id)),
+        onDeclineInvitation: (String id) => dispatch(DeclineInvitationAction(id)),
       );
 }
 
 class ViewModel extends Vm {
   final List<FriendRequestDto> pendingRequests;
+  final List<VisitInvitation> pendingInvitations;
   final Function(String friendshipId) onAccept;
   final Function(String friendshipId) onDecline;
+  final Function(String invitationId) onAcceptInvitation;
+  final Function(String invitationId) onDeclineInvitation;
 
   ViewModel({
     required this.pendingRequests,
+    required this.pendingInvitations,
     required this.onAccept,
     required this.onDecline,
+    required this.onAcceptInvitation,
+    required this.onDeclineInvitation,
   });
 
   @override
@@ -58,8 +73,10 @@ class ViewModel extends Vm {
       super == other &&
           other is ViewModel &&
           runtimeType == other.runtimeType &&
-          pendingRequests == other.pendingRequests;
+          pendingRequests == other.pendingRequests &&
+          pendingInvitations == other.pendingInvitations;
 
   @override
-  int get hashCode => super.hashCode ^ pendingRequests.hashCode;
+  int get hashCode =>
+      super.hashCode ^ pendingRequests.hashCode ^ pendingInvitations.hashCode;
 }

--- a/lib/screens/pending_invitations.dart
+++ b/lib/screens/pending_invitations.dart
@@ -51,7 +51,7 @@ class PendingInvitations extends StatelessWidget {
                         ),
                         const VerticalSpacer(4),
                         CustomText(
-                          "Invited by: ${invitation.inviterId ?? ''}",
+                          "Invited by: ${invitation.inviterName ?? invitation.inviterId ?? ''}",
                           style: Theme.of(context).textTheme.bodySmall,
                         ),
                         const VerticalSpacer(12),

--- a/lib/screens/places.dart
+++ b/lib/screens/places.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:gastrorate/models/auth/user.dart';
 import 'package:gastrorate/models/place.dart';
 import 'package:gastrorate/models/place_search_form.dart';
 import 'package:gastrorate/theme/my_colors.dart';
@@ -9,9 +10,7 @@ import 'package:gastrorate/theme/theme_helper.dart';
 import 'package:gastrorate/tools/place_helper.dart';
 import 'package:gastrorate/widgets/custom_app_bar.dart';
 import 'package:gastrorate/widgets/custom_text.dart';
-import 'package:gastrorate/widgets/default_button.dart';
 import 'package:gastrorate/widgets/place_card.dart';
-import 'package:gastrorate/widgets/vertical_spacer.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
@@ -25,13 +24,17 @@ class Places extends StatefulWidget {
       required this.sharedPlaces,
       required this.onFindAllPlaces,
       required this.onDeletePlace,
-      required this.onInitPlaceForm});
+      required this.onInitPlaceForm,
+      this.friends,
+      this.onInviteCoVisitor});
 
   final Function(PlaceSearchForm) onFindAllPlaces;
   final List<Place>? places;
   final List<Place>? sharedPlaces;
   final Function(Place place) onDeletePlace;
   final Function(Place place) onInitPlaceForm;
+  final List<User>? friends;
+  final Function(String placeId, String friendId)? onInviteCoVisitor;
 
   final GoogleMapsFlutterPlatform mapsImplementation = GoogleMapsFlutterPlatform.instance;
 
@@ -77,7 +80,7 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
     _getCurrentLocation().then((value) => initialPosition = LatLng(value.latitude, value.longitude));
     setState(() {
       _mapsInitialized = true;
-      (widget.mapsImplementation as GoogleMapsFlutterAndroid).useAndroidViewSurface = true;
+      (widget.mapsImplementation as GoogleMapsFlutterAndroid).useAndroidViewSurface = false;
     });
   }
 
@@ -183,6 +186,8 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
                         place: place,
                         onDeletePlace: widget.onDeletePlace,
                         onInitPlaceForm: widget.onInitPlaceForm,
+                        friends: widget.friends,
+                        onInviteCoVisitor: widget.onInviteCoVisitor,
                       );
                     },
                     itemCount: _places.length,
@@ -263,10 +268,11 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
                 selectedPlaceWidgetBuilder: (context, selectedPlace, state, isSearchBarFocused) =>
                     _defaultPlaceWidgetBuilder(context, selectedPlace, state),
                 zoomControlsEnabled: true,
+                autocompleteRadius: 50000,
+                autocompleteTypes: ['restaurant'],
                 onPlacePicked: (PickResult result) {
                   setState(() {
                     selectedPlace = Place.fromPickResult(result);
-                    // check if place is rated already
                     selectedPlace = _places.firstWhere(
                       (place) => place.url == selectedPlace?.url,
                       orElse: () => selectedPlace ?? Place(),
@@ -288,68 +294,135 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
 
   Widget _defaultPlaceWidgetBuilder(BuildContext context, PickResult? data, SearchingState state) {
     return FloatingCard(
-      bottomPosition: MediaQuery.of(context).size.height * 0.1,
-      leftPosition: MediaQuery.of(context).size.width * 0.15,
-      rightPosition: MediaQuery.of(context).size.width * 0.15,
-      width: MediaQuery.of(context).size.width * 0.7,
-      borderRadius: BorderRadius.circular(12.0),
-      elevation: 4.0,
+      bottomPosition: 0,
+      leftPosition: 0,
+      rightPosition: 0,
+      width: double.infinity,
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      elevation: 10.0,
       color: Theme.of(context).cardColor,
       child: state == SearchingState.Searching ? _buildLoadingIndicator() : _buildSelectionDetails(context, data!),
     );
   }
 
   Widget _buildLoadingIndicator() {
-    return Container(
-      height: 48,
-      child: const Center(
-        child: SizedBox(
-          width: 24,
-          height: 24,
-          child: CircularProgressIndicator(),
-        ),
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 32),
+      child: Center(
+        child: SizedBox(width: 28, height: 28, child: CircularProgressIndicator()),
       ),
     );
   }
 
   Widget _buildSelectionDetails(BuildContext context, PickResult result) {
     selectedPlace = Place.fromPickResult(result);
-    return Container(
-      margin: const EdgeInsets.all(10),
+    final rating = result.rating;
+    final openNow = result.openingHours?.openNow;
+    final priceLevelText = _priceLevelText(result.priceLevel?.index);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       child: Column(
-        children: <Widget>[
-          CustomText(
-            selectedPlace?.name ?? "",
-            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
-            textAlign: TextAlign.center,
-          ),
-          const VerticalSpacer(4),
-          CustomText(
-            "${selectedPlace?.address}, ${selectedPlace?.city}",
-            style: Theme.of(context).textTheme.bodyMedium,
-            softWrap: true,
-          ),
-          const VerticalSpacer(8),
-          SizedBox.fromSize(
-            size: const Size(60, 40),
-            child: Material(
-              child: ButtonComponent(
-                text: "GO",
-                onPressed: () {
-                  setState(() {
-                    selectedPlace = _places.firstWhere(
-                      (place) => place.url == selectedPlace?.url,
-                      orElse: () => selectedPlace ?? Place(),
-                    );
-                    widget.onInitPlaceForm(selectedPlace ?? Place());
-                  });
-                },
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 40, height: 4,
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(2),
               ),
             ),
-          )
+          ),
+          Text(
+            selectedPlace?.name ?? "",
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              if (rating != null) ...[
+                const Icon(Icons.star_rounded, color: Color(0xFFFFB300), size: 18),
+                const SizedBox(width: 3),
+                Text(rating.toStringAsFixed(1), style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14)),
+                const SizedBox(width: 12),
+              ],
+              if (priceLevelText != null) ...[
+                Text(priceLevelText, style: TextStyle(color: Colors.green.shade700, fontSize: 14, fontWeight: FontWeight.w600)),
+                const SizedBox(width: 12),
+              ],
+              if (openNow != null)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: openNow ? Colors.green.shade100 : Colors.red.shade100,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    openNow ? "Open now" : "Closed",
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: openNow ? Colors.green.shade800 : Colors.red.shade800,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.location_on_outlined, size: 16, color: Colors.grey.shade600),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  result.formattedAddress ?? "${selectedPlace?.address ?? ''}, ${selectedPlace?.city ?? ''}",
+                  style: TextStyle(fontSize: 13, color: Colors.grey.shade700),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: () {
+                setState(() {
+                  selectedPlace = _places.firstWhere(
+                    (place) => place.url == selectedPlace?.url,
+                    orElse: () => selectedPlace ?? Place(),
+                  );
+                  widget.onInitPlaceForm(selectedPlace ?? Place());
+                });
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: MyColors.primaryDarkColor,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+              ),
+              child: const Text("Select this place", style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: MyColors.navbarItemColor)),
+            ),
+          ),
         ],
       ),
     );
+  }
+
+  String? _priceLevelText(int? index) {
+    switch (index) {
+      case 1: return '€';
+      case 2: return '€€';
+      case 3: return '€€€';
+      case 4: return '€€€€';
+      default: return null;
+    }
   }
 
   PopupMenuButton<PlaceSorting> buildSortingButton() {

--- a/lib/screens/places_page.dart
+++ b/lib/screens/places_page.dart
@@ -1,10 +1,12 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:gastrorate/models/auth/user.dart';
 import 'package:gastrorate/models/from_where.dart';
 import 'package:gastrorate/models/place.dart';
 import 'package:gastrorate/models/place_search_form.dart';
 import 'package:gastrorate/screens/places.dart';
 import 'package:gastrorate/store/app_state.dart';
+import 'package:gastrorate/store/invitations/invitations_actions.dart';
 import 'package:gastrorate/store/places/places_actions.dart';
 
 class PlacesPage extends StatelessWidget {
@@ -27,6 +29,8 @@ class PlacesPage extends StatelessWidget {
         onFindAllPlaces: vm.onFindAllPlaces,
         onDeletePlace: vm.onDeletePlace,
         onInitPlaceForm: vm.onInitPlaceForm,
+        friends: vm.friends,
+        onInviteCoVisitor: vm.onInviteCoVisitor,
       ),
     );
   }
@@ -39,25 +43,31 @@ class Factory extends VmFactory<AppState, PlacesPage, ViewModel> {
   ViewModel? fromStore() => ViewModel(
     places: state.placesState.places,
     sharedPlaces: state.placesState.sharedPlaces,
+    friends: state.friendshipsState.friends,
     onFindAllPlaces: (PlaceSearchForm psf) => dispatch(FetchPlacesAction(placeSearchForm: psf)),
     onDeletePlace: (place) => dispatch(DeletePlaceAction(place)),
     onInitPlaceForm: (Place place) => dispatch(InitNewPlaceAction(payload: place, fromWhere: FromWhere.places)),
+    onInviteCoVisitor: (placeId, friendId) => dispatch(SendVisitInvitationAction(placeId, friendId)),
   );
 }
 
 class ViewModel extends Vm {
   final List<Place>? places;
   final List<Place>? sharedPlaces;
+  final List<User>? friends;
   final Function(PlaceSearchForm) onFindAllPlaces;
   final Function(Place place) onDeletePlace;
   final Function(Place place) onInitPlaceForm;
+  final Function(String placeId, String friendId) onInviteCoVisitor;
 
   ViewModel(
       {required this.places,
         required this.sharedPlaces,
+        required this.friends,
         required this.onFindAllPlaces,
         required this.onDeletePlace,
-        required this.onInitPlaceForm});
+        required this.onInitPlaceForm,
+        required this.onInviteCoVisitor});
 
   @override
   bool operator ==(Object other) =>
@@ -67,11 +77,13 @@ class ViewModel extends Vm {
               runtimeType == other.runtimeType &&
               places == other.places &&
               sharedPlaces == other.sharedPlaces &&
+              friends == other.friends &&
               onFindAllPlaces == other.onFindAllPlaces &&
               onDeletePlace == other.onDeletePlace &&
-              onInitPlaceForm == other.onInitPlaceForm;
+              onInitPlaceForm == other.onInitPlaceForm &&
+              onInviteCoVisitor == other.onInviteCoVisitor;
 
   @override
   int get hashCode =>
-      super.hashCode ^ places.hashCode ^ sharedPlaces.hashCode ^ onFindAllPlaces.hashCode ^ onDeletePlace.hashCode ^ onInitPlaceForm.hashCode;
+      super.hashCode ^ places.hashCode ^ sharedPlaces.hashCode ^ friends.hashCode ^ onFindAllPlaces.hashCode ^ onDeletePlace.hashCode ^ onInitPlaceForm.hashCode ^ onInviteCoVisitor.hashCode;
 }

--- a/lib/store/auth/auth.actions.dart
+++ b/lib/store/auth/auth.actions.dart
@@ -9,6 +9,7 @@ import 'package:gastrorate/service/auth_manager.dart';
 import 'package:gastrorate/store/app_action.dart';
 import 'package:gastrorate/store/app_state.dart';
 import 'package:gastrorate/store/friendships/friendships_actions.dart';
+import 'package:gastrorate/store/invitations/invitations_actions.dart';
 import 'package:gastrorate/store/places/places_actions.dart';
 import 'package:gastrorate/tools/toast_helper.dart';
 import 'package:go_router/go_router.dart';
@@ -21,8 +22,11 @@ class LoginAction extends AppAction {
   Future<AppState?> reduce() async{
     AuthResponse? authResponse = await AuthManager().login(payload);
     if (authResponse != null) {
-      dispatch(LoginSuccessAction(payload: authResponse));
+      await dispatchAndWait(LoginSuccessAction(payload: authResponse));
+      final userId = authResponse.user!.id!;
       dispatch(FetchPendingFriendRequestsAction());
+      dispatch(FetchFriendsAction(userId));
+      dispatch(FetchPendingInvitationsAction(userId));
       await dispatchAndWait(FetchPlacesAction());
       GoRouter.of(rootNavigatorKey.currentContext!).go('/home');
     } else {

--- a/lib/store/invitations/invitations_actions.dart
+++ b/lib/store/invitations/invitations_actions.dart
@@ -29,6 +29,8 @@ class AcceptInvitationAction extends AppAction {
   @override
   Future<AppState?> reduce() async {
     final UserVisit visit = await InvitationManager().acceptInvitation(invitationId);
+    final userId = state.authState.loggedUser!.id!;
+    dispatch(FetchPendingInvitationsAction(userId));
     rootNavigatorKey.currentContext!.push('/rate-shared-place');
     return state.copyWith(
       invitationsState: state.invitationsState.copyWith(activeVisit: visit),

--- a/lib/store/places/places_actions.dart
+++ b/lib/store/places/places_actions.dart
@@ -118,6 +118,13 @@ class FetchNearbyPlacesAction extends AppAction {
       return place;
     }));
 
+    places = places
+        .where((p) => p.photos != null && p.photos!.isNotEmpty)
+        .where((p) => p.googleRating != null && p.googleRating! >= 3.5)
+        .toList();
+    places.sort((a, b) => (a.distance ?? double.maxFinite).compareTo(b.distance ?? double.maxFinite));
+    if (places.length > 10) places = places.sublist(0, 10);
+
     dispatch(FetchNearbyPlacesSuccessAction(places));
     return null;
   }

--- a/lib/tools/location_helper.dart
+++ b/lib/tools/location_helper.dart
@@ -35,12 +35,13 @@ class LocationHelper {
         .getCurrentLocation()
         .then((value) => initialPosition = Coordinates(latitude: value.latitude, longitude: value.longitude));
     return NearbyPlacesSearchForm(
-      includedTypes: ['restaurant'],
-      maxResultCount: 10,
+      includedPrimaryTypes: ['restaurant'],
+      maxResultCount: 20,
+      rankPreference: 'POPULARITY',
       locationRestriction: LocationRestriction(
         circle: Circle(
           center: initialPosition!,
-          radius: 10000.0,
+          radius: 3000.0,
         ),
       ),
     );

--- a/lib/widgets/custom_app_bar.dart
+++ b/lib/widgets/custom_app_bar.dart
@@ -79,7 +79,8 @@ class _CustomAppBarState extends State<CustomAppBar> {
     return StoreConnector<AppState, _AppBarVm>(
       converter: (Store<AppState> store) => _AppBarVm(
         user: store.state.authState.loggedUser,
-        pendingCount: store.state.friendshipsState.pendingRequests?.length ?? 0,
+        pendingCount: (store.state.friendshipsState.pendingRequests?.length ?? 0) +
+            (store.state.invitationsState.pendingInvitations?.length ?? 0),
       ),
       builder: (context, vm) {
         return AppBar(

--- a/lib/widgets/place_card.dart
+++ b/lib/widgets/place_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:gastrorate/models/auth/user.dart';
 import 'package:gastrorate/models/place.dart';
 import 'package:gastrorate/theme/my_colors.dart';
 import 'package:gastrorate/widgets/custom_text.dart';
@@ -10,12 +11,16 @@ class PlaceCard extends StatelessWidget {
   final Place place;
   final Function(Place) onDeletePlace;
   final Function(Place) onInitPlaceForm;
+  final List<User>? friends;
+  final Function(String placeId, String friendId)? onInviteCoVisitor;
 
   const PlaceCard({
     Key? key,
     required this.place,
     required this.onDeletePlace,
     required this.onInitPlaceForm,
+    this.friends,
+    this.onInviteCoVisitor,
   }) : super(key: key);
 
   String _photoUrl(String ref, int maxWidth) {
@@ -29,6 +34,58 @@ class PlaceCard extends StatelessWidget {
     if (place.city != null && place.country != null) return "${place.city}, ${place.country}";
     if (place.address != null && place.address!.isNotEmpty) return place.address!;
     return "";
+  }
+
+  void _showInviteFriendSheet(BuildContext context) {
+    final friendList = friends ?? [];
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: CustomText(
+                "Invite a friend to ${place.name ?? 'this place'}",
+                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              ),
+            ),
+            if (friendList.isEmpty)
+              const Padding(
+                padding: EdgeInsets.all(24),
+                child: CustomText("No friends to invite yet."),
+              )
+            else
+              ...friendList.map((friend) => ListTile(
+                    leading: CircleAvatar(
+                      backgroundImage: friend.profileImageUrl != null
+                          ? NetworkImage(friend.profileImageUrl!)
+                          : null,
+                      child: friend.profileImageUrl == null
+                          ? Text(friend.getUserInitials())
+                          : null,
+                    ),
+                    title: CustomText(friend.getFullName()),
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      onInviteCoVisitor!(place.id!, friend.id!);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Invitation sent to ${friend.getFullName()}'),
+                          duration: const Duration(seconds: 2),
+                        ),
+                      );
+                    },
+                  )),
+          ],
+        ),
+      ),
+    );
   }
 
   void _showDeleteConfirmationDialog(BuildContext context) {
@@ -174,9 +231,20 @@ class PlaceCard extends StatelessWidget {
                         "⭐ ${place.googleRating}",
                         style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
                       ),
-                      IconButton(
-                        onPressed: () => _showDeleteConfirmationDialog(context),
-                        icon: const Icon(CupertinoIcons.delete_simple, color: Colors.red),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (onInviteCoVisitor != null)
+                            IconButton(
+                              onPressed: () => _showInviteFriendSheet(context),
+                              icon: const Icon(Icons.person_add_outlined, color: MyColors.primaryDarkColor),
+                              tooltip: "Invite friend",
+                            ),
+                          IconButton(
+                            onPressed: () => _showDeleteConfirmationDialog(context),
+                            icon: const Icon(CupertinoIcons.delete_simple, color: Colors.red),
+                          ),
+                        ],
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary

- **Co-visitor invitations**: friends/invitations fetched on login; PlaceCard invite button with friend picker sheet; visit invitations merged into Notifications screen with accept/decline; badge counts both friend requests + invitations; displays inviter's full name from enriched backend DTO
- **Nearby places quality**: `includedPrimaryTypes` (restaurants only, no hotels/museums), `rankPreference: POPULARITY`, client-side filter (photos required + rating ≥ 3.5), sorted by distance, top 10
- **PlacePicker UX**: location-biased search (`autocompleteRadius: 50000`), `useAndroidViewSurface = false` fixes blurry map; modern full-width bottom sheet card with rating, price level, open/closed badge, pin address, and full-width select button

## Test plan
- [ ] Login → friends and pending invitations load correctly
- [ ] Open PlaceCard → "Invite" icon visible, tapping opens friend list sheet, sending invite creates notification for friend
- [ ] Friend receives invite in Notifications; accept removes it from list; accepting navigates to rate-shared-place
- [ ] Notification bell badge reflects sum of friend requests + pending invitations
- [ ] Inviter name (not ID) shown on invitation card
- [ ] Nearby places (Home) shows only restaurants with photos and rating ≥ 3.5, sorted by distance
- [ ] PlacePicker map is sharp (not blurry) on Android
- [ ] Searching in PlacePicker biases to nearby results; bottom card shows rating, price, open status

🤖 Generated with [Claude Code](https://claude.com/claude-code)