### PR TITLE
fix: co-visitor rating update overwrites owner rating and stale card

### DIFF
--- a/lib/models/place.dart
+++ b/lib/models/place.dart
@@ -36,6 +36,8 @@ class Place {
   DateTime? visitedAt;
   bool? isFavorite;
   double? distance;
+  @JsonKey(includeToJson: false)
+  String? visitId;
 
   factory Place.fromJson(Map<String, dynamic> json) => _$PlaceFromJson(json);
 
@@ -123,6 +125,7 @@ class Place {
     this.visitedAt,
     this.isFavorite,
     this.distance,
+    this.visitId,
   });
 
   factory Place.fromPickResult(PickResult result) {
@@ -202,7 +205,8 @@ class Place {
               coVisitors == other.coVisitors &&
               visitedAt == other.visitedAt &&
               isFavorite == other.isFavorite &&
-              distance == other.distance);
+              distance == other.distance &&
+              visitId == other.visitId);
 
   @override
   int get hashCode =>
@@ -226,11 +230,12 @@ class Place {
       coordinates.hashCode ^
       visitedAt.hashCode ^
       isFavorite.hashCode ^
-      distance.hashCode;
+      distance.hashCode ^
+      visitId.hashCode;
 
   @override
   String toString() {
-    return 'Place{ id: $id, userId: $userId, name: $name, address: $address, city: $city, postalCode: $postalCode, country: $country, contactNumber: $contactNumber, openingHours: $openingHours, photos: $photos, priceLevel: $priceLevel, reviews: $reviews, googleRating: $googleRating, url: $url, webSiteUrl: $webSiteUrl, coordinates: $coordinates, rating: $rating, coVisitors: $coVisitors, visitedAt: $visitedAt, isFavorite: $isFavorite, distance: $distance }';
+    return 'Place{ id: $id, userId: $userId, name: $name, address: $address, city: $city, postalCode: $postalCode, country: $country, contactNumber: $contactNumber, openingHours: $openingHours, photos: $photos, priceLevel: $priceLevel, reviews: $reviews, googleRating: $googleRating, url: $url, webSiteUrl: $webSiteUrl, coordinates: $coordinates, rating: $rating, coVisitors: $coVisitors, visitedAt: $visitedAt, isFavorite: $isFavorite, distance: $distance, visitId: $visitId }';
   }
 
   Place copyWith({
@@ -255,6 +260,7 @@ class Place {
     DateTime? visitedAt,
     bool? isFavorite,
     double? distance,
+    String? visitId,
   }) {
     return Place(
       id: id ?? this.id,
@@ -278,6 +284,7 @@ class Place {
       visitedAt: visitedAt ?? this.visitedAt,
       isFavorite: isFavorite ?? this.isFavorite,
       distance: distance ?? this.distance,
+      visitId: visitId ?? this.visitId,
     );
   }
 
@@ -304,6 +311,7 @@ class Place {
       'visitedAt': visitedAt?.toIso8601String(),
       'isFavorite': isFavorite,
       'distance': distance,
+      'visitId': visitId,
     };
   }
 
@@ -334,6 +342,7 @@ class Place {
       visitedAt: map['visitedAt'] != null ? DateTime.parse(map['visitedAt']) : null,
       isFavorite: map['isFavorite'] as bool?,
       distance: map['distance'] as double?,
+      visitId: map['visitId'] as String?,
     );
   }
 }

--- a/lib/models/place.g.dart
+++ b/lib/models/place.g.dart
@@ -36,14 +36,16 @@ Place _$PlaceFromJson(Map<String, dynamic> json) => Place(
   rating: json['rating'] == null
       ? null
       : Rating.fromJson(json['rating'] as Map<String, dynamic>),
+  coVisitors: (json['coVisitors'] as List<dynamic>?)
+      ?.map((e) => CoVisitor.fromJson(e as Map<String, dynamic>))
+      .toList(),
   visitedAt: json['visitedAt'] == null
       ? null
       : DateTime.parse(json['visitedAt'] as String),
   isFavorite: json['isFavorite'] as bool?,
   distance: (json['distance'] as num?)?.toDouble(),
-)..coVisitors = (json['coVisitors'] as List<dynamic>?)
-    ?.map((e) => CoVisitor.fromJson(e as Map<String, dynamic>))
-    .toList();
+  visitId: json['visitId'] as String?,
+);
 
 Map<String, dynamic> _$PlaceToJson(Place instance) => <String, dynamic>{
   'id': instance.id,

--- a/lib/screens/new_place.dart
+++ b/lib/screens/new_place.dart
@@ -22,6 +22,7 @@ import 'package:gastrorate/widgets/review_swiper.dart';
 import 'package:gastrorate/widgets/vertical_spacer.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
+import 'package:gastrorate/tools/utils_helper.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class NewPlace extends StatefulWidget {
@@ -870,11 +871,11 @@ class _NewPlaceState extends State<NewPlace> {
             if (coVisitor.rating != null) ...[
               const VerticalSpacer(8),
               Text(
-                '${coVisitor.rating!.placeRating!.toStringAsFixed(0)}/30',
+                '${UtilsHelper.formatRating(coVisitor.rating!.placeRating)}/30',
                 style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
               ),
               Text(
-                'Experience: ${coVisitor.rating!.ambientRating?.toStringAsFixed(0)}/10 · Food: ${coVisitor.rating!.foodRating?.toStringAsFixed(0)}/10 · Price: ${coVisitor.rating!.priceRating?.toStringAsFixed(0)}/10',
+                'Experience: ${UtilsHelper.formatRating(coVisitor.rating!.ambientRating)}/10 · Food: ${UtilsHelper.formatRating(coVisitor.rating!.foodRating)}/10 · Price: ${UtilsHelper.formatRating(coVisitor.rating!.priceRating)}/10',
                 style: GoogleFonts.outfit(fontSize: 13, color: Colors.grey[600]),
               ),
             ],

--- a/lib/screens/new_place_page.dart
+++ b/lib/screens/new_place_page.dart
@@ -34,7 +34,14 @@ class Factory extends VmFactory<AppState, NewPlacePage, ViewModel> {
   ViewModel? fromStore() => ViewModel(
         foundPlace: state.placesState.place,
         friends: state.friendshipsState.friends,
-        onSavePlace: (Place place) => dispatch(SaveOrUpdatePlaceAction(place)),
+        onSavePlace: (Place place) {
+          final isOwner = place.userId == state.authState.loggedUser?.id;
+          if (isOwner || place.visitId == null) {
+            dispatch(SaveOrUpdatePlaceAction(place));
+          } else {
+            dispatch(UpdateCoVisitorRatingAction(place.visitId!, place.rating!));
+          }
+        },
         onDeletePlace: (place) => dispatch(DeletePlaceAction(place)),
         onInviteVisitor: (String placeId, String friendId) =>
             dispatch(SendVisitInvitationAction(placeId, friendId)),

--- a/lib/store/invitations/invitations_actions.dart
+++ b/lib/store/invitations/invitations_actions.dart
@@ -105,3 +105,17 @@ class RateVisitAction extends AppAction {
     );
   }
 }
+
+class UpdateCoVisitorRatingAction extends AppAction {
+  final String visitId;
+  final Rating rating;
+  UpdateCoVisitorRatingAction(this.visitId, this.rating);
+
+  @override
+  Future<AppState?> reduce() async {
+    await InvitationManager().rateVisit(visitId, rating);
+    final userId = state.authState.loggedUser!.id!;
+    dispatch(FetchSharedPlacesAction(userId));
+    return null;
+  }
+}

--- a/lib/tools/utils_helper.dart
+++ b/lib/tools/utils_helper.dart
@@ -5,4 +5,11 @@ class UtilsHelper {
     }
     return '';
   }
+
+  /// Formats a rating value without unnecessary decimals.
+  /// 8.0 → "8", 8.5 → "8.5"
+  static String formatRating(double? v) {
+    if (v == null) return '?';
+    return v % 1 == 0 ? v.toInt().toString() : v.toStringAsFixed(1);
+  }
 }

--- a/lib/widgets/place_rating_dialog.dart
+++ b/lib/widgets/place_rating_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gastrorate/tools/utils_helper.dart';
 import 'package:gastrorate/models/rating.dart';
 import 'package:gastrorate/widgets/custom_text.dart';
 import 'package:gastrorate/widgets/dialog_wrapper.dart';
@@ -17,9 +18,9 @@ class _PlaceRatingDialogState extends State<PlaceRatingDialog> {
   Widget build(BuildContext context) {
     return DialogWrapperWidget(
       children: [
-        CustomText("Experience: ${widget.rating.ambientRating}"),
+        CustomText("Experience: ${UtilsHelper.formatRating(widget.rating.ambientRating)}"),
         Slider(
-          label: "${widget.rating.ambientRating}",
+          label: UtilsHelper.formatRating(widget.rating.ambientRating),
           divisions: 18,
           min: 1,
           max: 10,
@@ -30,9 +31,9 @@ class _PlaceRatingDialogState extends State<PlaceRatingDialog> {
             });
           },
         ),
-        CustomText("Food: ${widget.rating.foodRating}"),
+        CustomText("Food: ${UtilsHelper.formatRating(widget.rating.foodRating)}"),
         Slider(
-          label: "${widget.rating.foodRating}",
+          label: UtilsHelper.formatRating(widget.rating.foodRating),
           divisions: 18,
           min: 1,
           max: 10,
@@ -43,9 +44,9 @@ class _PlaceRatingDialogState extends State<PlaceRatingDialog> {
             });
           },
         ),
-        CustomText("Price: ${widget.rating.priceRating}"),
+        CustomText("Price: ${UtilsHelper.formatRating(widget.rating.priceRating)}"),
         Slider(
-          label: "${widget.rating.priceRating}",
+          label: UtilsHelper.formatRating(widget.rating.priceRating),
           divisions: 18,
           min: 1,
           max: 10,


### PR DESCRIPTION
## Summary

- **Bug 1 — owner rating overwritten:** saving from place details always called `SaveOrUpdatePlaceAction`, which wrote the full `Place` document (with co-visitor's rating as `place.rating`) to MongoDB, overwriting the owner's original rating
- **Bug 2 — stale card after update:** `SaveOrUpdatePlaceAction` only dispatches `FetchPlacesAction` (own places), never `FetchSharedPlacesAction`, so the co-visitor's "Shared with Me" card stayed stale
- **Bug 3 — rating display rounding:** `toStringAsFixed(0)` rounded `8.5` → `"9"`; replaced with `UtilsHelper.formatRating` which keeps decimals only when needed (`8.5` → `"8.5"`, `8.0` → `"8"`)

## Changes

**Backend** (separate PR in places-backend):
- `PlaceResponse`: add `visitId` field
- `PlaceManagerImpl.findSharedPlaces`: populate `visitId` from the user's `UserVisit`

**Frontend:**
- `Place` model: add `visitId` field (`@JsonKey(includeToJson: false)` — received from API, never sent back)
- `invitations_actions`: new `UpdateCoVisitorRatingAction` — calls `POST /visits/{visitId}/rate` and refreshes `sharedPlaces`
- `NewPlacePage.onSavePlace`: routes co-visitors to `UpdateCoVisitorRatingAction`, owners stay on `SaveOrUpdatePlaceAction`
- `UtilsHelper.formatRating`: shared helper for decimal-aware rating display
- `new_place.dart`, `place_rating_dialog.dart`: use `UtilsHelper.formatRating` instead of `toStringAsFixed(0)`

## Test plan

- [x] Co-visitor updates rating → their card refreshes immediately with new value
- [x] Owner's rating unchanged after co-visitor update
- [x] Rating values like `8.5` display as `"8.5"`, not `"9"`, in both the co-visitor sheet and the rating dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)