### PR TITLE
feat: center nav bar Add Place button (#56)

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:gastrorate/models/place.dart';
-import 'package:gastrorate/screens/place_search_page.dart';
 import 'package:gastrorate/theme/my_colors.dart';
 import 'package:gastrorate/widgets/custom_app_bar.dart';
 import 'package:gastrorate/widgets/custom_text.dart';
@@ -34,38 +33,9 @@ class Home extends StatefulWidget {
 
 class _HomeState extends State<Home> {
   final ScrollController _scrollController = ScrollController();
-  bool _isVisible = true;
-  double _previousScrollOffset = 0;
-
-  // Detect scroll direction and show or hide the button
-  void _onScroll() {
-    if (widget.places == null || widget.places!.isEmpty) {
-      setState(() {
-        _isVisible = true;
-      });
-    } else if (_scrollController.offset > _previousScrollOffset && _isVisible) {
-      // Scrolling down, hide the button
-      setState(() {
-        _isVisible = false;
-      });
-    } else if (_scrollController.offset < _previousScrollOffset && !_isVisible) {
-      // Scrolling up, show the button
-      setState(() {
-        _isVisible = true;
-      });
-    }
-    _previousScrollOffset = _scrollController.offset;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _scrollController.addListener(_onScroll);
-  }
 
   @override
   void dispose() {
-    _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
   }
@@ -136,51 +106,6 @@ class _HomeState extends State<Home> {
           ],
         ]),
       ),
-      floatingActionButton: showAddPlaceButton()
-          ? AnimatedOpacity(
-              opacity: 1.0, duration: const Duration(milliseconds: 300), child: buildAddPlaceButton(context))
-          : const AnimatedOpacity(
-              opacity: 0.0,
-              duration: Duration(milliseconds: 200),
-              child: SizedBox.shrink(),
-            ),
     );
   }
-
-  bool showAddPlaceButton() => _isVisible || (widget.places == null || widget.places!.length < 2);
-
-  FloatingActionButton buildAddPlaceButton(BuildContext context) {
-    return FloatingActionButton.extended(
-      heroTag: 'home_fab',
-      icon: const Icon(Icons.add, color: MyColors.navbarItemColor),
-      label: const CustomText(
-        "Add Place",
-        style: TextStyle(color: MyColors.navbarItemColor),
-      ),
-      backgroundColor: MyColors.primaryDarkColor,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8.0),
-        side: const BorderSide(
-          color: Colors.black12,
-          width: 1,
-        ),
-      ),
-      onPressed: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => PlaceSearchPage(
-              existingPlaces: widget.places,
-              onPlaceSelected: widget.onInitPlaceForm,
-            ),
-          ),
-        );
-      },
-      elevation: 6.0,
-      focusElevation: 10.0,
-      highlightElevation: 8.0,
-      splashColor: Colors.white.withOpacity(0.3),
-    );
-  }
-
 }

--- a/lib/screens/places.dart
+++ b/lib/screens/places.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:gastrorate/models/auth/user.dart';
 import 'package:gastrorate/models/place.dart';
 import 'package:gastrorate/models/place_search_form.dart';
-import 'package:gastrorate/screens/place_search_page.dart';
 import 'package:gastrorate/theme/my_colors.dart';
 import 'package:gastrorate/tools/place_helper.dart';
 import 'package:gastrorate/widgets/custom_app_bar.dart';
@@ -46,8 +45,6 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
   int _currentTabIndex = 0;
 
   final ScrollController _scrollController = ScrollController();
-  bool _isVisible = true;
-  double _previousScrollOffset = 0;
 
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
@@ -71,22 +68,6 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
         (p.address?.toLowerCase().contains(q) ?? false)).toList();
   }
 
-  // Detect scroll direction and show or hide the button
-  void _onScroll() {
-    if (_scrollController.offset > _previousScrollOffset && _isVisible) {
-      // Scrolling down, hide the button
-      setState(() {
-        _isVisible = false;
-      });
-    } else if (_scrollController.offset < _previousScrollOffset && !_isVisible) {
-      // Scrolling up, show the button
-      setState(() {
-        _isVisible = true;
-      });
-    }
-    _previousScrollOffset = _scrollController.offset;
-  }
-
   @override
   void didUpdateWidget(covariant Places oldWidget) {
     if (widget.places != null){
@@ -107,13 +88,11 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
       _places = widget.places!;
       _places = PlaceHelper.sortPlaces(_places, _selectedSorting);
     }
-    _scrollController.addListener(_onScroll);
   }
 
   @override
   void dispose() {
     _tabController.dispose();
-    _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _searchController.dispose();
     super.dispose();
@@ -158,14 +137,6 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
           ),
         ],
       ),
-      floatingActionButton: showAddPlaceButton()
-          ? AnimatedOpacity(
-              opacity: 1.0, duration: const Duration(milliseconds: 300), child: buildAddPlaceButton(context))
-          : const AnimatedOpacity(
-              opacity: 0.0,
-              duration: Duration(milliseconds: 200),
-              child: SizedBox.shrink(),
-            ),
     );
   }
 
@@ -383,8 +354,6 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
     );
   }
 
-  bool showAddPlaceButton() => _currentTabIndex == 0 && (_isVisible || (_places.length < 3));
-
   List<Widget> buildEmptyState() {
     return <Widget>[
       Lottie.asset("assets/empty_state_places.json"),
@@ -393,40 +362,6 @@ class _PlacesState extends State<Places> with SingleTickerProviderStateMixin {
         style: Theme.of(context).textTheme.titleMedium,
       ),
     ];
-  }
-
-  FloatingActionButton buildAddPlaceButton(BuildContext context) {
-    return FloatingActionButton.extended(
-      heroTag: 'places_fab',
-      icon: const Icon(Icons.add, color: MyColors.navbarItemColor),
-      label: const CustomText(
-        "Add Place",
-        style: TextStyle(color: MyColors.navbarItemColor),
-      ),
-      backgroundColor: MyColors.primaryDarkColor,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8.0),
-        side: const BorderSide(
-          color: Colors.black12,
-          width: 1,
-        ),
-      ),
-      onPressed: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => PlaceSearchPage(
-              existingPlaces: widget.places,
-              onPlaceSelected: widget.onInitPlaceForm,
-            ),
-          ),
-        );
-      },
-      elevation: 6.0,
-      focusElevation: 10.0,
-      highlightElevation: 8.0,
-      splashColor: Colors.white.withOpacity(0.3),
-    );
   }
 
   PopupMenuButton<PlaceSorting> buildSortingButton() {

--- a/lib/widgets/scaffold_navbar.dart
+++ b/lib/widgets/scaffold_navbar.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:gastrorate/theme/my_colors.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:google_nav_bar/google_nav_bar.dart';
 
 class ScaffoldWithNavigationBar extends StatelessWidget {
   const ScaffoldWithNavigationBar({
@@ -10,49 +9,123 @@ class ScaffoldWithNavigationBar extends StatelessWidget {
     required this.body,
     required this.selectedIndex,
     required this.onDestinationSelected,
+    required this.onAddPlace,
   });
   final Widget body;
   final int selectedIndex;
   final ValueChanged<int> onDestinationSelected;
+  final VoidCallback onAddPlace;
+
+  // Map branch index (0–3) to visual index (0–4, skipping 2 for the "+" button)
+  int _branchToVisualIndex(int branch) => branch < 2 ? branch : branch + 1;
 
   @override
   Widget build(BuildContext context) {
+    final int visualIndex = _branchToVisualIndex(selectedIndex);
+
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: body,
-        bottomNavigationBar: Container(
-          color: MyColors.backgroundNavBarColor,
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(15, 15, 15, 15 + MediaQuery.of(context).padding.bottom),
-            child: GNav(
-              selectedIndex: selectedIndex,
-              color: MyColors.navbarItemColor,
-              activeColor: MyColors.navbarItemColor,
-              tabBackgroundColor: MyColors.activeItemColor,
-              padding: const EdgeInsets.all(10),
-              gap: 8,
-              onTabChange: onDestinationSelected,
-            tabs: [
-              GButton(
-                  icon: CupertinoIcons.home,
-                  textStyle: GoogleFonts.outfit(textStyle: const TextStyle(color: MyColors.navbarItemColor)),
-                  text: "Home"),
-              GButton(
-                  icon: CupertinoIcons.map_pin_ellipse,
-                  textStyle: GoogleFonts.outfit(textStyle: const TextStyle(color: MyColors.navbarItemColor)),
-                  text: "Places"),
-              GButton(
-                  icon: CupertinoIcons.heart_fill,
-                  textStyle: GoogleFonts.outfit(textStyle: const TextStyle(color: MyColors.navbarItemColor)),
-                  text: "Favorites"),
-              GButton(
-                  icon: CupertinoIcons.settings,
-                  textStyle: GoogleFonts.outfit(textStyle: const TextStyle(color: MyColors.navbarItemColor)),
-                  text: "Settings"),
+      bottomNavigationBar: Container(
+        color: MyColors.backgroundNavBarColor,
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+              15, 15, 15, 15 + MediaQuery.of(context).padding.bottom),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildNavItem(
+                visualIndex: 0,
+                currentVisualIndex: visualIndex,
+                icon: CupertinoIcons.home,
+                label: 'Home',
+                onTap: () => onDestinationSelected(0),
+              ),
+              _buildNavItem(
+                visualIndex: 1,
+                currentVisualIndex: visualIndex,
+                icon: CupertinoIcons.map_pin_ellipse,
+                label: 'Places',
+                onTap: () => onDestinationSelected(1),
+              ),
+              _buildAddButton(),
+              _buildNavItem(
+                visualIndex: 3,
+                currentVisualIndex: visualIndex,
+                icon: CupertinoIcons.heart_fill,
+                label: 'Favorites',
+                onTap: () => onDestinationSelected(2),
+              ),
+              _buildNavItem(
+                visualIndex: 4,
+                currentVisualIndex: visualIndex,
+                icon: CupertinoIcons.settings,
+                label: 'Settings',
+                onTap: () => onDestinationSelected(3),
+              ),
             ],
           ),
-          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildNavItem({
+    required int visualIndex,
+    required int currentVisualIndex,
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    final bool isActive = visualIndex == currentVisualIndex;
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: isActive ? MyColors.activeItemColor : Colors.transparent,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              color: MyColors.navbarItemColor,
+            ),
+            if (isActive) ...[
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: GoogleFonts.outfit(
+                  textStyle: const TextStyle(color: MyColors.navbarItemColor),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAddButton() {
+    return GestureDetector(
+      onTap: onAddPlace,
+      child: Container(
+        width: 50,
+        height: 50,
+        decoration: BoxDecoration(
+          color: MyColors.primaryDarkColor,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.black12),
+        ),
+        child: const Icon(
+          CupertinoIcons.add,
+          color: MyColors.navbarItemColor,
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/scaffold_nested_navigation.dart
+++ b/lib/widgets/scaffold_nested_navigation.dart
@@ -1,4 +1,10 @@
+import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
+import 'package:gastrorate/models/from_where.dart';
+import 'package:gastrorate/models/place.dart';
+import 'package:gastrorate/screens/place_search_page.dart';
+import 'package:gastrorate/store/app_state.dart';
+import 'package:gastrorate/store/places/places_actions.dart';
 import 'package:gastrorate/widgets/scaffold_navbar.dart';
 import 'package:gastrorate/widgets/scaffold_navrail.dart';
 import 'package:go_router/go_router.dart';
@@ -42,20 +48,58 @@ class _ScaffoldWithNestedNavigationState
       child: widget.navigationShell,
     );
 
-    return LayoutBuilder(builder: (context, constraints) {
-      if (constraints.maxWidth < 450) {
-        return ScaffoldWithNavigationBar(
-          body: body,
-          selectedIndex: widget.navigationShell.currentIndex,
-          onDestinationSelected: _goBranch,
-        );
-      } else {
-        return ScaffoldWithNavigationRail(
-          body: body,
-          selectedIndex: widget.navigationShell.currentIndex,
-          onDestinationSelected: _goBranch,
-        );
-      }
-    });
+    return StoreConnector<AppState, _NavVm>(
+      vm: () => _NavVmFactory(this),
+      builder: (context, vm) {
+        return LayoutBuilder(builder: (context, constraints) {
+          if (constraints.maxWidth < 450) {
+            return ScaffoldWithNavigationBar(
+              body: body,
+              selectedIndex: widget.navigationShell.currentIndex,
+              onDestinationSelected: _goBranch,
+              onAddPlace: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PlaceSearchPage(
+                    existingPlaces: vm.places,
+                    onPlaceSelected: vm.onInitPlaceForm,
+                  ),
+                ),
+              ),
+            );
+          } else {
+            return ScaffoldWithNavigationRail(
+              body: body,
+              selectedIndex: widget.navigationShell.currentIndex,
+              onDestinationSelected: _goBranch,
+            );
+          }
+        });
+      },
+    );
+  }
+}
+
+class _NavVm extends Vm {
+  final List<Place>? places;
+  final Function(Place) onInitPlaceForm;
+
+  _NavVm({
+    required this.places,
+    required this.onInitPlaceForm,
+  }) : super(equals: [places]);
+}
+
+class _NavVmFactory extends VmFactory<AppState, _ScaffoldWithNestedNavigationState, _NavVm> {
+  _NavVmFactory(super.connector);
+
+  @override
+  _NavVm fromStore() {
+    return _NavVm(
+      places: state.placesState.places,
+      onInitPlaceForm: (Place place) => dispatch(
+        InitNewPlaceAction(payload: place, fromWhere: FromWhere.places),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Removes the floating action buttons (FABs) and their scroll-visibility state/logic from `HomeScreen` and `PlacesScreen`
- Replaces the `GNav` bar with a custom 5-item Row: Home | Places | **⊕** | Favorites | Settings
- Center "+" button (circular, `MyColors.primaryDarkColor`) always visible from any tab — tapping opens `PlaceSearchPage` without switching the active tab
- `ScaffoldNestedNavigation` now wraps in a `StoreConnector` to supply `places` and dispatch `InitNewPlaceAction(fromWhere: FromWhere.places)`
- Editing existing places via `PlaceCard` and `PlaceCardSwiper` still works (uses `onInitPlaceForm` callback)

Closes #56

## Test plan

- [ ] Nav bar shows 5 items with "+" in center on all tabs
- [ ] Tapping "+" from any tab opens `PlaceSearchPage`; selecting a place navigates to `/places/details` (Places tab)
- [ ] Active tab highlight correctly maps branch indices 0–3 → visual indices 0,1,3,4
- [ ] Home and Places screens have no FAB
- [ ] Editing an existing place from `PlaceCard` still works
- [ ] `fvm flutter analyze` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)